### PR TITLE
enhance(omu,server): 権限の制限を少し緩和

### DIFF
--- a/packages/omu/src/omu/extension/permission/permission_extension.py
+++ b/packages/omu/src/omu/extension/permission/permission_extension.py
@@ -38,10 +38,9 @@ class PermissionExtension(Extension):
         for permission in permission_types:
             if permission.id in self.registered_permissions:
                 raise ValueError(f"Permission {permission.id} already registered")
-            if not permission.id.is_subpath_of(base_identifier):
-                raise ValueError(
-                    f"Permission identifier {permission.id} is not a subpart of app identifier {base_identifier}"
-                )
+            if not permission.id.is_namepath_equal(base_identifier, path_length=1):
+                msg = f"Permission identifier {permission.id} is not a subpath of {base_identifier}"
+                raise ValueError(msg)
             self.registered_permissions[permission.id] = permission
 
     def require(self, permission_id: Identifier):

--- a/packages/omu/src/omu/identifier.py
+++ b/packages/omu/src/omu/identifier.py
@@ -85,6 +85,18 @@ class Identifier(Model[str], Keyable):
             and self.path[: len(base.path)] == base.path
         )
 
+    def is_namepath_equal(
+        self,
+        other: Identifier,
+        path_length: int | None = None,
+    ) -> bool:
+        if path_length is None:
+            path_length = len(self.path)
+        return (
+            self.namespace == other.namespace
+            and self.path[:path_length] == other.path[:path_length]
+        )
+
     def join(self, *path: str) -> Identifier:
         return Identifier(self.namespace, *self.path, *path)
 

--- a/packages/server/src/omuserver/extension/permission/permission_extension.py
+++ b/packages/server/src/omuserver/extension/permission/permission_extension.py
@@ -70,10 +70,11 @@ class PermissionExtension:
     ) -> None:
         for permission in permissions:
             if not permission.id.is_subpath_of(session.app.id):
-                raise ValueError(
+                msg = (
                     f"Permission identifier {permission.id} "
                     f"is not a subpart of app identifier {session.app.id}"
                 )
+                raise ValueError(msg)
             self.permission_registry[permission.id] = permission
 
     def load_permissions(self) -> None:


### PR DESCRIPTION
## 内容
登録、権限の設定は今まで通り対象がセッションのidにぶら下がっている必要があるが
アクセス自体は権限がなくてもnamespaceと最初のpathさえ合ってればチェックをパスできるようにした